### PR TITLE
Move styled-components to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ as functions for [styled-components](https://github.com/styled-components/styled
 ## Install
 
 ``` bash
-yarn add styled-bootstrap-responsive-breakpoints
+yarn add styled-components styled-bootstrap-responsive-breakpoints
 
 # or
 
-npm install  styled-bootstrap-responsive-breakpoints --save
+npm install styled-components styled-bootstrap-responsive-breakpoints --save
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-bootstrap-responsive-breakpoints",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Bootstrap responsive breakpoints for styled-components (and other CSS-in-JS techniques)",
   "main": "index.es5.js",
   "repository": "https://github.com/petetnt/styled-bootstrap-responsive-breakpoints",
@@ -32,10 +32,11 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "16.0.0",
+    "styled-components": "^2.4.0",
     "webpack": "^2.3.3"
   },
-  "dependencies": {
-    "styled-components": "^2.3.3"
+  "peerDependencies": {
+    "styled-components": "^2.4.0"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
Fixes possible styled-components instances' duplications.

ie. Project installs styled-components@^1.x.x and module installs styled-components@^2.x.x